### PR TITLE
Fix Pharmacoscan database packaging

### DIFF
--- a/aldy/resources/genes/pharmacoscan/__init__.py
+++ b/aldy/resources/genes/pharmacoscan/__init__.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+# 786
+
+# Aldy source: __init__.py
+#   This file is subject to the terms and conditions defined in
+#   file 'LICENSE', which is part of this source code package.

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,10 @@ setup(
         "aldy.resources.genes": [
             "*.yml",
             "aldy/resources/genes/*.yml",
-            "aldy/tests/resources/pharmacoscan/*.yml",
+        ],
+        "aldy.resources.genes.pharmacoscan": [
+            "*.yml",
+            "aldy/resources/genes/pharmacoscan/*.yml",
         ],
         "aldy.resources.profiles": ["*.yml", "aldy/resources/profiles/*.yml"],
         "aldy.tests.resources": [


### PR DESCRIPTION
## Test Environment

Created by `conda` on Linux.

- python: 3.10.8
- pytest: 7.2.2
- pip: 23.0.1
- setuptools: 67.6.1

## Description

Pharmacoscan database is currently NOT packaged into wheels.

Project developers might be running Aldy from [editable installs](https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs) instead of [regular installs](https://pip.pypa.io/en/stable/topics/local-project-installs/#regular-installs) so it isn't immediately obvious.

Running `aldy test` as advised after a regular install will fail with message:

```
ERROR: pharmacoscan/cyp2d6 cannot be accessed
```

This patch fixes the issue.