### PR TITLE
Fully support CYP2C19*37 minor alleles

### DIFF
--- a/aldy/resources/genes/cyp2c19.yml
+++ b/aldy/resources/genes/cyp2c19.yml
@@ -649,10 +649,10 @@ alleles:
     activity: no function
     mutations:
       - [CYP2C19, 'deletion:e8,i8,e9']
-  CYP2C19*37.015:
-    activity: no function
-    mutations:
-      - [CYP2C19, 'deletion:e?']
+  # CYP2C19*37.015:
+  #   activity: no function
+  #   mutations:
+  #     - [CYP2C19, 'deletion:e?']
   CYP2C19*38.001:
     pharmvar: https://www.pharmvar.org/haplotype/81
     activity: normal function

--- a/aldy/resources/genes/cyp2c19.yml
+++ b/aldy/resources/genes/cyp2c19.yml
@@ -10,597 +10,649 @@ alleles:
     label: CYP2C19*1B
     evidence: D
     mutations:
-    - [5124, C>T, rs17885098]
-    - [85186, A>G, rs3758581, I331V]
+      - [5124, C>T, rs17885098]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*1.003:
     pharmvar: https://www.pharmvar.org/haplotype/77
     activity: normal function
     label: CYP2C19*1C
     evidence: L
     mutations:
-    - [85186, A>G, rs3758581, I331V]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*1.004:
     pharmvar: https://www.pharmvar.org/haplotype/421
     activity: normal function
     evidence: D
     mutations:
-    - [3608, C>T, rs3814637]
-    - [4137, T>G, rs11568732]
-    - [85186, A>G, rs3758581, I331V]
-    - [85254, C>T, rs17882744]
-    - [92338, A>C, rs17886522]
+      - [3608, C>T, rs3814637]
+      - [4137, T>G, rs11568732]
+      - [85186, A>G, rs3758581, I331V]
+      - [85254, C>T, rs17882744]
+      - [92338, A>C, rs17886522]
   CYP2C19*1.005:
     pharmvar: https://www.pharmvar.org/haplotype/425
     activity: normal function
     evidence: D
     mutations:
-    - [3608, C>T, rs3814637]
-    - [4137, T>G, rs11568732]
-    - [85186, A>G, rs3758581, I331V]
+      - [3608, C>T, rs3814637]
+      - [4137, T>G, rs11568732]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*1.006:
     pharmvar: https://www.pharmvar.org/haplotype/73
     activity: normal function
     label: CYP2C19*27
     evidence: D
     mutations:
-    - [3985, G>A, rs7902257]
-    - [5124, C>T, rs17885098]
-    - [85186, A>G, rs3758581, I331V]
+      - [3985, G>A, rs7902257]
+      - [5124, C>T, rs17885098]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*1.007:
     pharmvar: https://www.pharmvar.org/haplotype/1541
     activity: normal function
     evidence: D
     mutations:
-    - [3608, C>T, rs3814637]
-    - [3635, T>G, rs11568730]
-    - [4137, T>G, rs11568732]
-    - [85186, A>G, rs3758581, I331V]
-    - [92338, A>C, rs17886522]
+      - [3608, C>T, rs3814637]
+      - [3635, T>G, rs11568730]
+      - [4137, T>G, rs11568732]
+      - [85186, A>G, rs3758581, I331V]
+      - [92338, A>C, rs17886522]
   CYP2C19*1.008:
     pharmvar: https://www.pharmvar.org/haplotype/1531
     activity: normal function
     evidence: D
     mutations:
-    - [4251, T>A, rs185375194]
-    - [5124, C>T, rs17885098]
-    - [85186, A>G, rs3758581, I331V]
+      - [4251, T>A, rs185375194]
+      - [5124, C>T, rs17885098]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*1.009:
     pharmvar: https://www.pharmvar.org/haplotype/1542
     activity: normal function
     evidence: D
     mutations:
-    - [3854, delT, rs771491246]
-    - [5124, C>T, rs17885098]
-    - [85186, A>G, rs3758581, I331V]
+      - [3854, delT, rs771491246]
+      - [5124, C>T, rs17885098]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*1.010:
     pharmvar: https://www.pharmvar.org/haplotype/1537
     activity: normal function
     evidence: D
     mutations:
-    - [3098, G>A, rs141540628]
-    - [5124, C>T, rs17885098]
-    - [85186, A>G, rs3758581, I331V]
+      - [3098, G>A, rs141540628]
+      - [5124, C>T, rs17885098]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*2.001:
     pharmvar: https://www.pharmvar.org/haplotype/111
     activity: no function
     label: CYP2C19*2A
     evidence: L
     mutations:
-    - [5124, C>T, rs17885098]
-    - [17687, A>G, rs12769205, splice defect]
-    - [24179, G>A, rs4244285, splice defect]
-    - [85185, C>T, rs3758580]
-    - [85186, A>G, rs3758581, I331V]
+      - [5124, C>T, rs17885098]
+      - [17687, A>G, rs12769205, splice defect]
+      - [24179, G>A, rs4244285, splice defect]
+      - [85185, C>T, rs3758580]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*2.002:
     pharmvar: https://www.pharmvar.org/haplotype/112
     activity: no function
     label: CYP2C19*2B
     evidence: D
     mutations:
-    - [4928, T>C, rs4986894]
-    - [5124, C>T, rs17885098]
-    - [17485, G>C, rs17878459, E92D]
-    - [17687, A>G, rs12769205, splice defect]
-    - [24179, G>A, rs4244285, splice defect]
-    - [85185, C>T, rs3758580]
-    - [85186, A>G, rs3758581, I331V]
+      - [4928, T>C, rs4986894]
+      - [5124, C>T, rs17885098]
+      - [17485, G>C, rs17878459, E92D]
+      - [17687, A>G, rs12769205, splice defect]
+      - [24179, G>A, rs4244285, splice defect]
+      - [85185, C>T, rs3758580]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*2.003:
     pharmvar: https://www.pharmvar.org/haplotype/106
     activity: no function
     label: CYP2C19*2C
     evidence: D
     mutations:
-    - [4928, T>C, rs4986894]
-    - [5124, C>T, rs17885098]
-    - [17687, A>G, rs12769205, splice defect]
-    - [17859, G>C, rs181297724, A161P]
-    - [24179, G>A, rs4244285, splice defect]
-    - [85185, C>T, rs3758580]
-    - [85186, A>G, rs3758581, I331V]
+      - [4928, T>C, rs4986894]
+      - [5124, C>T, rs17885098]
+      - [17687, A>G, rs12769205, splice defect]
+      - [17859, G>C, rs181297724, A161P]
+      - [24179, G>A, rs4244285, splice defect]
+      - [85185, C>T, rs3758580]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*2.004:
     pharmvar: https://www.pharmvar.org/haplotype/107
     activity: no function
     label: CYP2C19*2D
     evidence: L
     mutations:
-    - [4928, T>C, rs4986894]
-    - [5124, C>T, rs17885098]
-    - [17687, A>G, rs12769205, splice defect]
-    - [24179, G>A, rs4244285, splice defect]
-    - [85185, C>T, rs3758580]
-    - [85186, A>G, rs3758581, I331V]
-    - [92300, G>A, rs780225316]
+      - [4928, T>C, rs4986894]
+      - [5124, C>T, rs17885098]
+      - [17687, A>G, rs12769205, splice defect]
+      - [24179, G>A, rs4244285, splice defect]
+      - [85185, C>T, rs3758580]
+      - [85186, A>G, rs3758581, I331V]
+      - [92300, G>A, rs780225316]
   CYP2C19*2.005:
     pharmvar: https://www.pharmvar.org/haplotype/104
     activity: no function
     label: CYP2C19*2E
     evidence: L
     mutations:
-    - [5124, C>T, rs17885098]
-    - [17687, A>G, rs12769205, splice defect]
-    - [24179, G>A, rs4244285, splice defect]
-    - [24311, G>A, rs778258371]
-    - [85185, C>T, rs3758580]
-    - [85186, A>G, rs3758581, I331V]
+      - [5124, C>T, rs17885098]
+      - [17687, A>G, rs12769205, splice defect]
+      - [24179, G>A, rs4244285, splice defect]
+      - [24311, G>A, rs778258371]
+      - [85185, C>T, rs3758580]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*2.006:
     pharmvar: https://www.pharmvar.org/haplotype/105
     activity: no function
     label: CYP2C19*2F
     evidence: L
     mutations:
-    - [5124, C>T, rs17885098]
-    - [17687, A>G, rs12769205, splice defect]
-    - [24179, G>A, rs4244285, splice defect]
-    - [85185, C>T, rs3758580]
-    - [85186, A>G, rs3758581, I331V]
-    - [85216, G>A, rs770829708]
+      - [5124, C>T, rs17885098]
+      - [17687, A>G, rs12769205, splice defect]
+      - [24179, G>A, rs4244285, splice defect]
+      - [85185, C>T, rs3758580]
+      - [85186, A>G, rs3758581, I331V]
+      - [85216, G>A, rs770829708]
   CYP2C19*2.007:
     pharmvar: https://www.pharmvar.org/haplotype/109
     activity: no function
     label: CYP2C19*2G
     evidence: L
     mutations:
-    - [5124, C>T, rs17885098]
-    - [17687, A>G, rs12769205, splice defect]
-    - [24179, G>A, rs4244285, splice defect]
-    - [85185, C>T, rs3758580]
-    - [85186, A>G, rs3758581, I331V]
-    - [85274, A>T, rs550527959]
+      - [5124, C>T, rs17885098]
+      - [17687, A>G, rs12769205, splice defect]
+      - [24179, G>A, rs4244285, splice defect]
+      - [85185, C>T, rs3758580]
+      - [85186, A>G, rs3758581, I331V]
+      - [85274, A>T, rs550527959]
   CYP2C19*2.008:
     pharmvar: https://www.pharmvar.org/haplotype/110
     activity: no function
     label: CYP2C19*2H
     evidence: L
     mutations:
-    - [5124, C>T, rs17885098]
-    - [17687, A>G, rs12769205, splice defect]
-    - [24179, G>A, rs4244285, splice defect]
-    - [85185, C>T, rs3758580]
-    - [85186, A>G, rs3758581, I331V]
-    - [92273, C>G, rs1564686367]
+      - [5124, C>T, rs17885098]
+      - [17687, A>G, rs12769205, splice defect]
+      - [24179, G>A, rs4244285, splice defect]
+      - [85185, C>T, rs3758580]
+      - [85186, A>G, rs3758581, I331V]
+      - [92273, C>G, rs1564686367]
   CYP2C19*2.009:
     pharmvar: https://www.pharmvar.org/haplotype/108
     activity: no function
     label: CYP2C19*2J
     evidence: L
     mutations:
-    - [5124, C>T, rs17885098]
-    - [17687, A>G, rs12769205, splice defect]
-    - [24179, G>A, rs4244285, splice defect]
-    - [85185, C>T, rs3758580]
-    - [85186, A>G, rs3758581, I331V]
-    - [92348, A>C, '-']
+      - [5124, C>T, rs17885098]
+      - [17687, A>G, rs12769205, splice defect]
+      - [24179, G>A, rs4244285, splice defect]
+      - [85185, C>T, rs3758580]
+      - [85186, A>G, rs3758581, I331V]
+      - [92348, A>C, '-']
   CYP2C19*2.010:
     pharmvar: https://www.pharmvar.org/haplotype/422
     activity: no function
     evidence: L
     mutations:
-    - [4928, T>C, rs4986894]
-    - [5124, C>T, rs17885098]
-    - [17485, G>C, rs17878459, E92D]
-    - [17687, A>G, rs12769205, splice defect]
-    - [17827, G>A, rs58973490, R150H]
-    - [24179, G>A, rs4244285, splice defect]
-    - [85185, C>T, rs3758580]
-    - [85186, A>G, rs3758581, I331V]
+      - [4928, T>C, rs4986894]
+      - [5124, C>T, rs17885098]
+      - [17485, G>C, rs17878459, E92D]
+      - [17687, A>G, rs12769205, splice defect]
+      - [17827, G>A, rs58973490, R150H]
+      - [24179, G>A, rs4244285, splice defect]
+      - [85185, C>T, rs3758580]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*2.011:
     pharmvar: https://www.pharmvar.org/haplotype/1529
     activity: no function
     evidence: D
     mutations:
-    - [4928, T>C, rs4986894]
-    - [5124, C>T, rs17885098]
-    - [17687, A>G, rs12769205, splice defect]
-    - [24179, G>A, rs4244285, splice defect]
-    - [85185, C>T, rs3758580]
-    - [85186, A>G, rs3758581, I331V]
+      - [4928, T>C, rs4986894]
+      - [5124, C>T, rs17885098]
+      - [17687, A>G, rs12769205, splice defect]
+      - [24179, G>A, rs4244285, splice defect]
+      - [85185, C>T, rs3758580]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*2.012:
     pharmvar: https://www.pharmvar.org/haplotype/1543
     activity: no function
     evidence: D
     mutations:
-    - [4928, T>C, rs4986894]
-    - [5124, C>T, rs17885098]
-    - [17485, G>C, rs17878459, E92D]
-    - [17687, A>G, rs12769205, splice defect]
-    - [24179, G>A, rs4244285, splice defect]
-    - [85185, C>T, rs3758580]
-    - [85186, A>G, rs3758581, I331V]
+      - [4928, T>C, rs4986894]
+      - [5124, C>T, rs17885098]
+      - [17485, G>C, rs17878459, E92D]
+      - [17687, A>G, rs12769205, splice defect]
+      - [24179, G>A, rs4244285, splice defect]
+      - [85185, C>T, rs3758580]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*3.001:
     pharmvar: https://www.pharmvar.org/haplotype/85
     activity: no function
     label: CYP2C19*3A
     evidence: L
     mutations:
-    - [22973, G>A, rs4986893, W212X]
-    - [85186, A>G, rs3758581, I331V]
-    - [92338, A>C, rs17886522]
+      - [22973, G>A, rs4986893, W212X]
+      - [85186, A>G, rs3758581, I331V]
+      - [92338, A>C, rs17886522]
   CYP2C19*3.002:
     pharmvar: https://www.pharmvar.org/haplotype/79
     activity: no function
     label: CYP2C19*3B
     evidence: L
     mutations:
-    - [4137, T>G, rs11568732]
-    - [22973, G>A, rs4986893, W212X]
-    - [23936, A>G, rs7088784]
-    - [85186, A>G, rs3758581, I331V]
-    - [85273, G>A, rs144036596, D360N]
-    - [92338, A>C, rs17886522]
+      - [4137, T>G, rs11568732]
+      - [22973, G>A, rs4986893, W212X]
+      - [23936, A>G, rs7088784]
+      - [85186, A>G, rs3758581, I331V]
+      - [85273, G>A, rs144036596, D360N]
+      - [92338, A>C, rs17886522]
   CYP2C19*3.003:
     pharmvar: https://www.pharmvar.org/haplotype/82
     activity: no function
     label: CYP2C19*3C
     evidence: L
     mutations:
-    - [17785, T>A, rs763625282, M136K]
-    - [22973, G>A, rs4986893, W212X]
-    - [85186, A>G, rs3758581, I331V]
-    - [92338, A>C, rs17886522]
+      - [17785, T>A, rs763625282, M136K]
+      - [22973, G>A, rs4986893, W212X]
+      - [85186, A>G, rs3758581, I331V]
+      - [92338, A>C, rs17886522]
   CYP2C19*3.004:
     pharmvar: https://www.pharmvar.org/haplotype/1539
     activity: no function
     evidence: D
     mutations:
-    - [3608, C>T, rs3814637]
-    - [4137, T>G, rs11568732]
-    - [22973, G>A, rs4986893, W212X]
-    - [85186, A>G, rs3758581, I331V]
-    - [92338, A>C, rs17886522]
+      - [3608, C>T, rs3814637]
+      - [4137, T>G, rs11568732]
+      - [22973, G>A, rs4986893, W212X]
+      - [85186, A>G, rs3758581, I331V]
+      - [92338, A>C, rs17886522]
   CYP2C19*4.001:
     pharmvar: https://www.pharmvar.org/haplotype/113
     activity: no function
     label: CYP2C19*4A
     evidence: D
     mutations:
-    - [5026, A>G, rs28399504, M1V]
-    - [5124, C>T, rs17885098]
-    - [85186, A>G, rs3758581, I331V]
+      - [5026, A>G, rs28399504, M1V]
+      - [5124, C>T, rs17885098]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*4.002:
     pharmvar: https://www.pharmvar.org/haplotype/855
     activity: no function
     label: CYP2C19*4B
     evidence: L
     mutations:
-    - [4220, C>T, rs12248560, expression]
-    - [5026, A>G, rs28399504, M1V]
-    - [5124, C>T, rs17885098]
-    - [85186, A>G, rs3758581, I331V]
+      - [4220, C>T, rs12248560, expression]
+      - [5026, A>G, rs28399504, M1V]
+      - [5124, C>T, rs17885098]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*5.001:
     pharmvar: https://www.pharmvar.org/haplotype/78
     activity: no function
     label: CYP2C19*5A
     evidence: L
     mutations:
-    - [85186, A>G, rs3758581, I331V]
-    - [95058, C>T, rs56337013, R433W]
+      - [85186, A>G, rs3758581, I331V]
+      - [95058, C>T, rs56337013, R433W]
   CYP2C19*5.002:
     pharmvar: https://www.pharmvar.org/haplotype/84
     activity: no function
     label: CYP2C19*5B
     evidence: L
     mutations:
-    - [5124, C>T, rs17885098]
-    - [85186, A>G, rs3758581, I331V]
-    - [95058, C>T, rs56337013, R433W]
+      - [5124, C>T, rs17885098]
+      - [85186, A>G, rs3758581, I331V]
+      - [95058, C>T, rs56337013, R433W]
   CYP2C19*6.001:
     pharmvar: https://www.pharmvar.org/haplotype/89
     activity: no function
     label: CYP2C19*6
     evidence: D
     mutations:
-    - [5124, C>T, rs17885098]
-    - [17773, G>A, rs72552267, R132Q]
-    - [85186, A>G, rs3758581, I331V]
+      - [5124, C>T, rs17885098]
+      - [17773, G>A, rs72552267, R132Q]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*7.001:
     pharmvar: https://www.pharmvar.org/haplotype/83
     activity: no function
     label: CYP2C19*7
     evidence: L
     mutations:
-    - [24319, T>A, rs72558186, splice defect]
-    - [85186, A>G, rs3758581, I331V]
+      - [24319, T>A, rs72558186, splice defect]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*8.001:
     pharmvar: https://www.pharmvar.org/haplotype/80
     activity: no function
     label: CYP2C19*8
     evidence: L
     mutations:
-    - [17736, T>C, rs41291556, W120R]
-    - [85186, A>G, rs3758581, I331V]
+      - [17736, T>C, rs41291556, W120R]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*8.002:
     pharmvar: https://www.pharmvar.org/haplotype/1538
     activity: no function
     evidence: D
     mutations:
-    - [3041, C>T, rs117673124]
-    - [3608, C>T, rs3814637]
-    - [4120, A>G, rs186694202]
-    - [17736, T>C, rs41291556, W120R]
-    - [85186, A>G, rs3758581, I331V]
+      - [3041, C>T, rs117673124]
+      - [3608, C>T, rs3814637]
+      - [4120, A>G, rs186694202]
+      - [17736, T>C, rs41291556, W120R]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*9.001:
     pharmvar: https://www.pharmvar.org/haplotype/86
     activity: decreased function
     label: CYP2C19*9
     evidence: M
     mutations:
-    - [5124, C>T, rs17885098]
-    - [17809, G>A, rs17884712, R144H]
-    - [85186, A>G, rs3758581, I331V]
+      - [5124, C>T, rs17885098]
+      - [17809, G>A, rs17884712, R144H]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*9.002:
     pharmvar: https://www.pharmvar.org/haplotype/1533
     activity: decreased function
     evidence: D
     mutations:
-    - [4243, C>T, rs11568729]
-    - [5124, C>T, rs17885098]
-    - [17809, G>A, rs17884712, R144H]
-    - [85186, A>G, rs3758581, I331V]
+      - [4243, C>T, rs11568729]
+      - [5124, C>T, rs17885098]
+      - [17809, G>A, rs17884712, R144H]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*10.001:
     pharmvar: https://www.pharmvar.org/haplotype/98
     activity: decreased function
     label: CYP2C19*10
     evidence: M
     mutations:
-    - [5124, C>T, rs17885098]
-    - [24178, C>T, rs6413438, P227L]
-    - [85186, A>G, rs3758581, I331V]
+      - [5124, C>T, rs17885098]
+      - [24178, C>T, rs6413438, P227L]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*11.001:
     pharmvar: https://www.pharmvar.org/haplotype/100
     activity: normal function
     label: CYP2C19*11
     evidence: M
     mutations:
-    - [5124, C>T, rs17885098]
-    - [17827, G>A, rs58973490, R150H]
-    - [85186, A>G, rs3758581, I331V]
+      - [5124, C>T, rs17885098]
+      - [17827, G>A, rs58973490, R150H]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*12.001:
     pharmvar: https://www.pharmvar.org/haplotype/90
     activity: uncertain function
     label: CYP2C19*12
     evidence: M
     mutations:
-    - [5124, C>T, rs17885098]
-    - [85186, A>G, rs3758581, I331V]
-    - [95234, A>C, rs55640102, X491C]
+      - [5124, C>T, rs17885098]
+      - [85186, A>G, rs3758581, I331V]
+      - [95234, A>C, rs55640102, X491C]
   CYP2C19*13.001:
     pharmvar: https://www.pharmvar.org/haplotype/92
     activity: normal function
     label: CYP2C19*13
     evidence: M
     mutations:
-    - [85186, A>G, rs3758581, I331V]
-    - [92315, C>T, rs17879685, R410C]
+      - [85186, A>G, rs3758581, I331V]
+      - [92315, C>T, rs17879685, R410C]
   CYP2C19*13.002:
     pharmvar: https://www.pharmvar.org/haplotype/1530
     activity: normal function
     evidence: D
     mutations:
-    - [3041, C>T, rs117673124]
-    - [3608, C>T, rs3814637]
-    - [85186, A>G, rs3758581, I331V]
-    - [92315, C>T, rs17879685, R410C]
+      - [3041, C>T, rs117673124]
+      - [3608, C>T, rs3814637]
+      - [85186, A>G, rs3758581, I331V]
+      - [92315, C>T, rs17879685, R410C]
   CYP2C19*14.001:
     pharmvar: https://www.pharmvar.org/haplotype/87
     activity: uncertain function
     label: CYP2C19*14
     evidence: M
     mutations:
-    - [5075, T>C, rs55752064, L17P]
-    - [5124, C>T, rs17885098]
-    - [85186, A>G, rs3758581, I331V]
+      - [5075, T>C, rs55752064, L17P]
+      - [5124, C>T, rs17885098]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*15.001:
     pharmvar: https://www.pharmvar.org/haplotype/88
     activity: normal function
     label: CYP2C19*15
     evidence: D
     mutations:
-    - [3587, T>C, rs17878739]
-    - [3608, C>T, rs3814637]
-    - [5080, A>C, rs17882687, I19L]
-    - [85186, A>G, rs3758581, I331V]
+      - [3587, T>C, rs17878739]
+      - [3608, C>T, rs3814637]
+      - [5080, A>C, rs17882687, I19L]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*15.002:
     pharmvar: https://www.pharmvar.org/haplotype/1535
     activity: normal function
     evidence: D
     mutations:
-    - [3123, G>T, rs150732393]
-    - [3587, T>C, rs17878739]
-    - [3608, C>T, rs3814637]
-    - [3918, G>C, rs140164087]
-    - [4193, delT, rs17880036]
-    - [4243, C>T, rs11568729]
-    - [5080, A>C, rs17882687, I19L]
-    - [85186, A>G, rs3758581, I331V]
+      - [3123, G>T, rs150732393]
+      - [3587, T>C, rs17878739]
+      - [3608, C>T, rs3814637]
+      - [3918, G>C, rs140164087]
+      - [4193, delT, rs17880036]
+      - [4243, C>T, rs11568729]
+      - [5080, A>C, rs17882687, I19L]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*16.001:
     pharmvar: https://www.pharmvar.org/haplotype/96
     activity: decreased function
     label: CYP2C19*16
     evidence: L
     mutations:
-    - [95085, C>T, rs192154563, R442C]
+      - [95085, C>T, rs192154563, R442C]
   CYP2C19*17.001:
     pharmvar: https://www.pharmvar.org/haplotype/856
     activity: increased function
     label: CYP2C19*17
     evidence: D
     mutations:
-    - [4220, C>T, rs12248560, expression]
-    - [5124, C>T, rs17885098]
-    - [85186, A>G, rs3758581, I331V]
+      - [4220, C>T, rs12248560, expression]
+      - [5124, C>T, rs17885098]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*18.001:
     pharmvar: https://www.pharmvar.org/haplotype/94
     activity: normal function
     label: CYP2C19*18
     evidence: L
     mutations:
-    - [5124, C>T, rs17885098]
-    - [85181, G>A, rs138142612, R329H]
-    - [85186, A>G, rs3758581, I331V]
+      - [5124, C>T, rs17885098]
+      - [85181, G>A, rs138142612, R329H]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*19.001:
     pharmvar: https://www.pharmvar.org/haplotype/95
     activity: decreased function
     label: CYP2C19*19
     evidence: L
     mutations:
-    - [5124, C>T, rs17885098]
-    - [5176, A>G, rs1564657013, S51G]
-    - [85186, A>G, rs3758581, I331V]
+      - [5124, C>T, rs17885098]
+      - [5176, A>G, rs1564657013, S51G]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*22.001:
     pharmvar: https://www.pharmvar.org/haplotype/75
     activity: no function
     label: CYP2C19*22
     evidence: L
     mutations:
-    - [22894, G>C, rs140278421, R186P]
-    - [85186, A>G, rs3758581, I331V]
+      - [22894, G>C, rs140278421, R186P]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*23.001:
     pharmvar: https://www.pharmvar.org/haplotype/70
     activity: uncertain function
     label: CYP2C19*23
     evidence: M
     mutations:
-    - [5124, C>T, rs17885098]
-    - [17480, G>C, rs118203756, G91R]
-    - [85186, A>G, rs3758581, I331V]
+      - [5124, C>T, rs17885098]
+      - [17480, G>C, rs118203756, G91R]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*24.001:
     pharmvar: https://www.pharmvar.org/haplotype/71
     activity: no function
     label: CYP2C19*24
     evidence: M
     mutations:
-    - [5124, C>T, rs17885098]
-    - [85186, A>G, rs3758581, I331V]
-    - [85199, G>A, rs118203757, R335Q]
-    - [92284, A>G, rs377184510]
+      - [5124, C>T, rs17885098]
+      - [85186, A>G, rs3758581, I331V]
+      - [85199, G>A, rs118203757, R335Q]
+      - [92284, A>G, rs377184510]
   CYP2C19*25.001:
     pharmvar: https://www.pharmvar.org/haplotype/68
     activity: decreased function
     label: CYP2C19*25
     evidence: M
     mutations:
-    - [5124, C>T, rs17885098]
-    - [85186, A>G, rs3758581, I331V]
-    - [95105, C>G, rs118203759, F448L]
+      - [5124, C>T, rs17885098]
+      - [85186, A>G, rs3758581, I331V]
+      - [95105, C>G, rs118203759, F448L]
   CYP2C19*26.001:
     pharmvar: https://www.pharmvar.org/haplotype/69
     activity: decreased function
     label: CYP2C19*26
     evidence: L
     mutations:
-    - [5124, C>T, rs17885098]
-    - [24264, G>A, rs375781227, D256N]
-    - [85186, A>G, rs3758581, I331V]
+      - [5124, C>T, rs17885098]
+      - [24264, G>A, rs375781227, D256N]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*28.001:
     pharmvar: https://www.pharmvar.org/haplotype/727
     activity: normal function
     label: CYP2C19*28
     evidence: M
     mutations:
-    - [3587, T>C, rs17878739]
-    - [5080, A>C, rs17882687, I19L]
-    - [85186, A>G, rs3758581, I331V]
-    - [85315, G>A, rs113934938, V374I]
+      - [3587, T>C, rs17878739]
+      - [5080, A>C, rs17882687, I19L]
+      - [85186, A>G, rs3758581, I331V]
+      - [85315, G>A, rs113934938, V374I]
   CYP2C19*29.001:
     pharmvar: https://www.pharmvar.org/haplotype/72
     activity: uncertain function
     label: CYP2C19*29
     evidence: L
     mutations:
-    - [5108, A>T, rs1564656981, K28I]
-    - [5124, C>T, rs17885098]
-    - [85186, A>G, rs3758581, I331V]
+      - [5108, A>T, rs1564656981, K28I]
+      - [5124, C>T, rs17885098]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*30.001:
     pharmvar: https://www.pharmvar.org/haplotype/102
     activity: uncertain function
     label: CYP2C19*30
     evidence: L
     mutations:
-    - [17426, C>T, rs145328984, R73C]
+      - [17426, C>T, rs145328984, R73C]
   CYP2C19*31.001:
     pharmvar: https://www.pharmvar.org/haplotype/103
     activity: uncertain function
     label: CYP2C19*31
     evidence: L
     mutations:
-    - [5124, C>T, rs17885098]
-    - [17441, C>T, rs1564660997, H78Y]
-    - [85186, A>G, rs3758581, I331V]
+      - [5124, C>T, rs17885098]
+      - [17441, C>T, rs1564660997, H78Y]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*32.001:
     pharmvar: https://www.pharmvar.org/haplotype/99
     activity: uncertain function
     label: CYP2C19*32
     evidence: L
     mutations:
-    - [5124, C>T, rs17885098]
-    - [17505, A>G, rs1288601658, H99R]
-    - [85186, A>G, rs3758581, I331V]
+      - [5124, C>T, rs17885098]
+      - [17505, A>G, rs1288601658, H99R]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*33.001:
     pharmvar: https://www.pharmvar.org/haplotype/101
     activity: uncertain function
     label: CYP2C19*33
     evidence: L
     mutations:
-    - [5124, C>T, rs17885098]
-    - [22899, G>A, rs370803989, D188N]
-    - [85186, A>G, rs3758581, I331V]
+      - [5124, C>T, rs17885098]
+      - [22899, G>A, rs370803989, D188N]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*34.001:
     pharmvar: https://www.pharmvar.org/haplotype/91
     activity: uncertain function
     label: CYP2C19*34
     evidence: D
     mutations:
-    - [5013, G>A, rs367543001]
-    - [5032, C>T, rs367543002, P3S]
-    - [5035, T>C, rs367543003, F4L]
+      - [5013, G>A, rs367543001]
+      - [5032, C>T, rs367543002, P3S]
+      - [5035, T>C, rs367543003, F4L]
   CYP2C19*35.001:
     pharmvar: https://www.pharmvar.org/haplotype/93
     activity: no function
     label: CYP2C19*35
     evidence: D
     mutations:
-    - [4113, G>A, rs76822098]
-    - [5124, C>T, rs17885098]
-    - [17687, A>G, rs12769205, splice defect]
-    - [85186, A>G, rs3758581, I331V]
+      - [4113, G>A, rs76822098]
+      - [5124, C>T, rs17885098]
+      - [17687, A>G, rs12769205, splice defect]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*35.002:
     pharmvar: https://www.pharmvar.org/haplotype/1540
     activity: no function
     evidence: D
     mutations:
-    - [5080, A>C, rs17882687, I19L]
-    - [5124, C>T, rs17885098]
-    - [17687, A>G, rs12769205, splice defect]
-    - [85186, A>G, rs3758581, I331V]
+      - [5080, A>C, rs17882687, I19L]
+      - [5124, C>T, rs17885098]
+      - [17687, A>G, rs12769205, splice defect]
+      - [85186, A>G, rs3758581, I331V]
   CYP2C19*36.001:
     activity: no function
     mutations:
-    - [CYP2C19, deletion]
+      - [CYP2C19, deletion]
     ignored: true
   CYP2C19*37.001:
     activity: no function
     mutations:
-    - [CYP2C19, "deletion:e2,i2,e3,i3,e4,i4,e5"]
+      - [CYP2C19, 'deletion:e1,i1,e2,i2,e3,i3,e4,i4,e5']
+  CYP2C19*37.002:
+    activity: no function
+    mutations:
+      - [CYP2C19, 'deletion:e1,i1,e2,i2,e3,i3,e4']
+  CYP2C19*37.003:
+    activity: no function
+    mutations:
+      - [CYP2C19, 'deletion:e1']
+  CYP2C19*37.004:
+    activity: no function
+    mutations:
+      - [CYP2C19, deletion:e1, i1, e2, i2, e3, i3, e4, i4, e5, i5, e6, i6, e7"]
+  CYP2C19*37.006:
+    activity: no function
+    mutations:
+      - [CYP2C19, 'deletion:e1,i1,e2,i2,e3']
+  CYP2C19*37.007:
+    activity: no function
+    mutations:
+      - [CYP2C19, 'deletion:e1,i1,e2,i2,e3,i3,e4,i4,e5,i5,e6']
+  CYP2C19*37.008:
+    activity: no function
+    mutations:
+      - [CYP2C19, 'deletion:e1,i1,e2,i2,e3,i3,e4,i4,e5,i5,e6,i6,e7,i7,e8']
+  CYP2C19*37.009:
+    activity: no function
+    mutations:
+      - [CYP2C19, 'deletion:e2,i2,e3,i3,e4,i4,e5']
+  CYP2C19*37.010:
+    activity: no function
+    mutations:
+      - [CYP2C19, 'deletion:e2,i2,e3,i3,e4,i4,e5,i5,e6']
+  CYP2C19*37.011:
+    activity: no function
+    mutations:
+      - [CYP2C19, 'deletion:e2,i2,e3,i3,e4,i4,e5,i5,e6,i6,e7,i7,e8,i8,e9']
+  CYP2C19*37.012:
+    activity: no function
+    mutations:
+      - [CYP2C19, 'deletion:e6']
+  CYP2C19*37.013:
+    activity: no function
+    mutations:
+      - [CYP2C19, 'deletion:e6,i6,e7']
+  CYP2C19*37.014:
+    activity: no function
+    mutations:
+      - [CYP2C19, 'deletion:e8,i8,e9']
+  CYP2C19*37.015:
+    activity: no function
+    mutations:
+      - [CYP2C19, 'deletion:e?']
   CYP2C19*38.001:
     pharmvar: https://www.pharmvar.org/haplotype/81
     activity: normal function

--- a/aldy/resources/genes/cyp2c19.yml
+++ b/aldy/resources/genes/cyp2c19.yml
@@ -612,31 +612,31 @@ alleles:
     activity: normal function
     evidence: D
     mutations:
-    - [3608, C>T, rs3814637]
-    - [4137, T>G, rs11568732]
-    - [4956, T>C, rs17886301]
+      - [3608, C>T, rs3814637]
+      - [4137, T>G, rs11568732]
+      - [4956, T>C, rs17886301]
   CYP2C19*38.003:
     pharmvar: https://www.pharmvar.org/haplotype/1536
     activity: normal function
     evidence: D
     mutations:
-    - [3608, C>T, rs3814637]
-    - [4137, T>G, rs11568732]
+      - [3608, C>T, rs3814637]
+      - [4137, T>G, rs11568732]
   CYP2C19*39.001:
     pharmvar: https://www.pharmvar.org/haplotype/1532
     activity: function not assigned
     evidence: D
     mutations:
-    - [3587, T>C, rs17878739]
-    - [3608, C>T, rs3814637]
-    - [4193, delT, rs17880036]
-    - [5080, A>C, rs17882687, I19L]
-    - [17743, A>C, rs17885179, E122A]
-    - [17768, G>T, rs17882291]
-    - [62899, A>G, rs17879239]
-    - [85186, A>G, rs3758581, I331V]
-    - [85254, C>T, rs17882744]
-    - [95316, T>C, rs17882796]
+      - [3587, T>C, rs17878739]
+      - [3608, C>T, rs3814637]
+      - [4193, delT, rs17880036]
+      - [5080, A>C, rs17882687, I19L]
+      - [17743, A>C, rs17885179, E122A]
+      - [17768, G>T, rs17882291]
+      - [62899, A>G, rs17879239]
+      - [85186, A>G, rs3758581, I331V]
+      - [85254, C>T, rs17882744]
+      - [95316, T>C, rs17882796]
 structure:
   genes: [CYP2C19]
   regions:
@@ -675,15 +675,15 @@ reference:
     hg19: ['10', 96517438, 96617309, +, M99871]
     hg38: ['10', 94757681, 94857552, +, M99871]
   exons:
-  - [5025, 5193]
-  - [17377, 17540]
-  - [17709, 17859]
-  - [22818, 22979]
-  - [24140, 24317]
-  - [62815, 62957]
-  - [85156, 85344]
-  - [92236, 92378]
-  - [95052, 95234]
+    - [5025, 5193]
+    - [17377, 17540]
+    - [17709, 17859]
+    - [22818, 22979]
+    - [24140, 24317]
+    - [62815, 62957]
+    - [85156, 85344]
+    - [92236, 92378]
+    - [95052, 95234]
   seq: |-
     GGAGTTTGCTGGAGGTCCACTCCAGGGCCTGTTTTCCTGGGTATCACCAGCAGAGGCTGCAGAACAGCAAATATTG
     CAGAACAGCAAGTATTGCTGCTTGATCCTTCCTCTGGAAGCTTCATCTCGGAGGGGCACCTGGCTGTGTGAGGTGT


### PR DESCRIPTION
This PR adds support for `CYP2C19*37` minor alleles. `*37` is defined as partial deletion within CYP2C19 lacking _at least_ `exon 1`. With the expectation that all deletions with `exon 1` result in a frameshift. Below I've explained the rationale for the alleles we're suggesting. 

- `*37.001`-`*37.004` were defined based on **Table 2** in PharmVar's CYP2C19 structural variation document: https://a.storyblok.com/f/70677/x/ae8cc4f43e/cyp2c19_variation_v1-1.pdf

_**Table 2 CYP2C19 Partial Gene Deletions.** All variants lack at least exon 1_

| **Allele** | **Exons deleted** |
|------------|-------------------|
| `*37.001`    |               1-5 |
| `*37.002`    |               1-4 |
| `*37.003`    |                 1 |
| `*37.004`    |               1-7 |

- `*37.005` and `*37.004` are identical but are defined separately due to the `CYP2C19*38` alleles that can result from the deletion. We skip `*37.005` in the Aldy config as a result.
- `*37.006`-`*37.014` are defined based on internal data and variant curation and annotation. While PharmVar defines `*37` alleles as lacking at least exon1, we've expanded this to include other observed deletions that are either frameshifts or remove a domain required for activity. 
  - `*37.009`-`*37.011`, deletions starting at exon2, are out of frame
  - `*37.012`, `del e6`, is out of frame 
  - `*37.013`, `del e6-e7`, is in frame but removes a portion of the heme binding pocket and is likely to result in a no-function allele (PMID 23116231)
  - `*37.014`, `del e8-e9`, is out of frame 
  - `*37.015`, `del exon?`, is a catchall for unknown combinations that are likely to be very rare. All other combinations of exon deletion result in a frameshift


We've verified that these definitions enable calling of all these alleles using historical data.