### PR TITLE
Add CYP2D6*6.ALDY for potential in cis 6.004/6.005 

### DIFF
--- a/aldy/resources/genes/cyp2d6.yml
+++ b/aldy/resources/genes/cyp2d6.yml
@@ -1699,6 +1699,15 @@ alleles:
     - [6266, C>T, rs267608277]
     - [6727, delT, rs5030655, W152fs]
     - [6996, G>A, rs5030866, G212E]
+  CYP2D6*6.ALDY:
+    pharmvar: https://www.pharmvar.org/haplotype/712
+    activity: no function
+    label: CYP2D6*6
+    evidence: D
+    mutations:
+    - [6727, delT, rs5030655, W152fs]
+    - [6996, G>A, rs5030866, G212E]
+    - [8308, G>A, rs61737946, G373S]
   CYP2D6*7.001:
     pharmvar: https://www.pharmvar.org/haplotype/155
     activity: no function


### PR DESCRIPTION
I suspect this PR will be a bit more contentious then the #83...

As a follow up from our emails on low fraction alleles and phasing (relevant context pasted below for others), I was hoping I could convince you to support a new `*6.ALDY` allele that includes the refining variants from `*6.004` and `*6.005`.

We've identified cases where adjusting the filtering threshold upwards also results in incorrect calls. Whereas adding an exact match allele, which is ultimately selected in these cases, alleviates the issue. 


<details><summary>Context</summary>
<p>

> There are also two low fraction variants called that are the defining alleles for *6B (rs61737946) and *6D (rs5030866). I've confirmed via IGV that these are indeed low fraction calls (22% and 26% AF, respectively).  Aldy seems to be confused by these two low fraction variants and thinks there are two *6 copies. This is can't be possible though if the deletion allele rs5030655 is single copy. I believe these two minor allele variants should be phased together and no minor allele called leading to `*1/*6`.

</p>
</details> 
