### PR TITLE
Include setuptools as a dependency for python>=3.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
         "mappy",
         "numpy",
         "cython",
+        "setuptools; python_version>='3.12'",
     ],
     entry_points={"console_scripts": ["aldy = aldy.__main__:console"]},
     packages=find_packages(),


### PR DESCRIPTION
`pkg_resources` is deleted in 3.12 - which means setuptools will need to be present at runtime for the same functionality.

https://docs.python.org/3/whatsnew/3.12.html
https://github.com/python/cpython/issues/95299