### PR TITLE
handle Path objects from importlib_resources correctly

### DIFF
--- a/aldy/genotype.py
+++ b/aldy/genotype.py
@@ -100,9 +100,9 @@ def genotype(
     if gene_db == "all":
         avail_genes = importlib_resources.files("aldy.resources.genes").iterdir()
         avail_genes = [
-            i[:-4]
+            i.name[:-4]
             for i in avail_genes
-            if len(i) > 4 and i.endswith(".yml") and not i.startswith("pharma-")
+            if len(i.name) > 4 and i.name.endswith(".yml") and not i.name.startswith("pharma-")
         ]
         avail_genes = sorted(avail_genes)
     elif gene_db == "pharmacoscan":
@@ -110,7 +110,7 @@ def genotype(
             "aldy.resources.genes.pharmacoscan"
         ).iterdir()
         avail_genes = [
-            f"pharmacoscan/{i[:-4]}" for i in avail_genes if i.endswith(".yml")
+            f"pharmacoscan/{i.name[:-4]}" for i in avail_genes if i.name.endswith(".yml")
         ]
         avail_genes = sorted(avail_genes)
     else:


### PR DESCRIPTION
The recent change to use `importlib_resources.files` causes aldy to break if not running on a single gene, as it returns pathlib objects and not strings. This corrects the issue.

Note: I got `pathlib.PosixPath` objects in the exception, but the type hints in `importlib_resources` have their own special abc class that doesn't guarantee the full functionality of the pathlib classes.